### PR TITLE
Fixed parsing seqs, and enum indexed arrays

### DIFF
--- a/src/flatty.nim
+++ b/src/flatty.nim
@@ -123,6 +123,7 @@ proc fromFlatty*[T](s: string, i: var int, x: var seq[T]) =
   when not defined(js) and T.supportsCopyMem:
     if len > 0:
       copyMem(x[0].addr, s[i].unsafeAddr, len * sizeof(T))
+      i += sizeof(T)
   else:
     for j in 0 ..< len:
       s.fromFlatty(i, x[j])
@@ -212,7 +213,7 @@ proc toFlatty*[N, T](s: var string, x: array[N, T]) =
     let byteLen = x.len * sizeof(T)
     s.setLen(s.len + byteLen)
     let dest = s[s.len - byteLen].addr
-    copyMem(dest, x[0].unsafeAddr, byteLen)
+    copyMem(dest, x[0.N].unsafeAddr, byteLen)
   else:
     for e in x:
       s.toFlatty(e)
@@ -220,7 +221,8 @@ proc toFlatty*[N, T](s: var string, x: array[N, T]) =
 proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T]) =
   when not defined(js) and T.supportsCopyMem:
     if x.len > 0:
-      copyMem(x[0].addr, s[i].unsafeAddr, sizeof(x))
+      copyMem(x[0.N].addr, s[i].unsafeAddr, sizeof(x))
+      i += sizeof(x)
   else:
     for j in 0 ..< x.len:
       s.fromFlatty(i, x[j])

--- a/src/flatty.nim
+++ b/src/flatty.nim
@@ -161,7 +161,7 @@ proc toFlatty*(s: var string, x: ref object) =
         when k != x.discriminatorFieldName:
           s.toFlatty(e)
     else:
-      for _, e in x[].fieldPairs:
+      for e in x[].fields:
         s.toFlatty(e)
 
 proc fromFlatty*(s: string, i: var int, x: var ref object) =
@@ -177,7 +177,7 @@ proc fromFlatty*(s: string, i: var int, x: var ref object) =
           s.fromFlatty(i, e)
     else:
       new(x)
-      for _, e in x[].fieldPairs:
+      for e in x[].fields:
         s.fromFlatty(i, e)
 
 # Distinct
@@ -229,11 +229,11 @@ proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T]) =
 
 # Tuples
 proc toFlatty*[T: tuple](s: var string, x: T) =
-  for _, e in x.fieldPairs:
+  for e in x.fields:
     s.toFlatty(e)
 
 proc fromFlatty*[T: tuple](s: string, i: var int, x: var T) =
-  for _, e in x.fieldPairs:
+  for e in x.fields:
     s.fromFlatty(i, e)
 
 proc toFlatty*[T](x: T): string =

--- a/src/flatty.nim
+++ b/src/flatty.nim
@@ -123,10 +123,10 @@ proc fromFlatty*[T](s: string, i: var int, x: var seq[T]) =
   when not defined(js) and T.supportsCopyMem:
     if len > 0:
       copyMem(x[0].addr, s[i].unsafeAddr, len * sizeof(T))
-      i += sizeof(T)
+      i += sizeof(T) * len.int
   else:
-    for j in 0 ..< len:
-      s.fromFlatty(i, x[j])
+    for j in x.mitems:
+      s.fromFlatty(i, j)
 
 # Objects
 proc toFlatty*(s: var string, x: object) =
@@ -136,7 +136,7 @@ proc toFlatty*(s: var string, x: object) =
       when k != x.discriminatorFieldName:
         s.toFlatty(e)
   else:
-    for _, e in x.fieldPairs:
+    for e in x.fields:
       s.toFlatty(e)
 
 proc fromFlatty*(s: string, i: var int, x: var object) =
@@ -148,7 +148,7 @@ proc fromFlatty*(s: string, i: var int, x: var object) =
       when k != x.discriminatorFieldName:
         s.fromFlatty(i, e)
   else:
-    for _, e in x.fieldPairs:
+    for e in x.fields:
       s.fromFlatty(i, e)
 
 proc toFlatty*(s: var string, x: ref object) =
@@ -224,8 +224,8 @@ proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T]) =
       copyMem(x[0.N].addr, s[i].unsafeAddr, sizeof(x))
       i += sizeof(x)
   else:
-    for j in 0 ..< x.len:
-      s.fromFlatty(i, x[j.N])
+    for j in x.mitems:
+      s.fromFlatty(i, j)
 
 # Tuples
 proc toFlatty*[T: tuple](s: var string, x: T) =

--- a/src/flatty.nim
+++ b/src/flatty.nim
@@ -225,7 +225,7 @@ proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T]) =
       i += sizeof(x)
   else:
     for j in 0 ..< x.len:
-      s.fromFlatty(i, x[j])
+      s.fromFlatty(i, x[j.N])
 
 # Tuples
 proc toFlatty*[T: tuple](s: var string, x: T) =

--- a/tests/test_flatty.nim
+++ b/tests/test_flatty.nim
@@ -167,3 +167,36 @@ block:
 
 var jsonNode = parseJson("{\"json\": true, \"count\":20}")
 doAssert jsonNode.toFlatty.fromFlatty(type(jsonNode)) == jsonNode
+
+# Enum indexed array
+block:
+  type Colors = enum
+    red, green, yellow, blue
+  let a = [
+    red: 100,
+    green: 300,
+    yellow: -100,
+    blue: 42
+  ]
+  doAssert a.toFlatty.fromFlatty(a.typeof) == a
+
+# Complex object
+block:
+  type
+    SubObject = object
+      a: int64
+      b: string
+    BigObject = object
+      subs: seq[SubObject]
+      arr: array[bool, SubObject]
+  let a = BigObject(
+    subs: @[
+      SubObject(a: 100, b: "Hmm"),
+      SubObject(a: 20, b: "Heh")
+      ],
+    arr:[
+      false: SubObject(a: 42, b: "Ahhh"),
+      true: SubObject(a: 31415, b: "Pi")
+    ]
+    )
+  doAssert a.toFlatty.fromFlatty(a.typeof) == a


### PR DESCRIPTION
Prior to this you couldnt serialize enum indexed arrays. and deserializing an object with a sequence would ruin anything after the sequence.