### PR TITLE
[codex] migrate CI to Nimby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,25 +1,25 @@
 name: Github Actions
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v5
-    - uses: jiro4989/setup-nim-action@v2
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - run: nim js -r tests/jstest.nim
-    - run: nim js -r tests/jstest_jsbinny.nim
-    - run: nim c -r tests/test_binny.nim
-    - run: nim c -r tests/test_datetime.nim
-    - run: nim c -r tests/test_flatty.nim
-    - run: nim c -r tests/test_hashy.nim
-    - run: nim c -r tests/test_hexprint.nim
-    - run: nim c -r tests/test_memoryused.nim
-    - run: nim c -r tests/test_objvar.nim
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim r tests/tests.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,24 +3,28 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+permissions:
+  contents: write
 env:
-  nim-version: 'stable'
   nim-src: src/${{ github.event.repository.name }}.nim
   deploy-dir: .gh-pages
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: ${{ env.nim-version }}
-      - run: nimble install -Y
-      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
       - name: Deploy documents
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.deploy-dir }}

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,0 +1,4 @@
+import test_binny, test_datetime, test_flatty, test_hashy, test_hexprint,
+    test_memoryused, test_objvar
+
+echo "all tests pass"


### PR DESCRIPTION
## What changed

- Migrated the build workflow to `treeform/setup-nim-action@v6` and Nimby dependency installation from the workspace parent.
- Standardized CI to run `nim r tests/tests.nim` on Ubuntu, macOS, and Windows without custom memory-manager or thread flags.
- Migrated the docs workflow to the new setup action, Nimby install pattern, manual dispatch, and the required `nim doc` invocation.
- Added `tests/tests.nim` as the native aggregate test entrypoint for the existing Flatty CI modules.

## Why

This brings Flatty onto the new Nim build system and matches the repository GitHub Actions standard.

## Validation

- `cd ..; nimby install -g flatty/flatty.nimble`
- `nim r tests/tests.nim`
- `nim doc --index:on --project --git.url:https://github.com/treeform/flatty --git.commit:master --out:.gh-pages src/flatty.nim`