### PR TITLE
[codex] support more Nim object shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This library has no dependencies other than the Nim standard library.
 * Also includes `binny` a simpler replacement for StringStream (no IO effects, operates on a string)
 * Also includes `hashy` a hash for any objects based on the flatty serializer.
 * Also includes `encode` a way to convert to/from utf16 BE/LE and with BOM and utf32.
+* Only Nim-owned values are serialized. Raw pointers, cstrings, procs, and distinct OS handles are rejected.
 
 ## Speed
 

--- a/src/flatty.nim
+++ b/src/flatty.nim
@@ -1,35 +1,125 @@
 ## Convert any Nim objects, numbers, strings, refs to and from binary format.
-import 
+import
   std/[tables, typetraits, sets],
   flatty/objvar
-  
+
 when defined(js):
   import flatty/jsbinny
 else:
   import flatty/binny
+  import std/[asyncdispatch, nativesockets]
 
 type SomeTable*[K, V] = Table[K, V] | OrderedTable[K, V]
 type SomeSet[A] = set[A] | HashSet[A] | OrderedSet[A]
 
+when not defined(js):
+  type UnsupportedHandle = AsyncFD | SocketHandle
+
+const unsupportedTypeMsg =
+  "flatty can only serialize Nim-owned values; raw pointers, cstrings, procs, " &
+  "and distinct OS handles cannot be flattened"
+
+func skipsFlattyCopyMem[T](_: typedesc[T]): bool =
+  when defined(js):
+    false
+  else:
+    T is UnsupportedHandle
+
+func copyable[T](_: typedesc[T]): bool =
+  when not T.supportsCopyMem:
+    false
+  elif skipsFlattyCopyMem(T):
+    false
+  elif (T is pointer) or (T is ptr) or (T is cstring) or (T is proc):
+    false
+  elif T is distinct:
+    typeof(default(T).distinctBase).copyable
+  elif T is object:
+    when default(T).isObjectVariant:
+      false
+    else:
+      block:
+        var ok {.compileTime.} = true
+        for field in default(T).fields:
+          ok = ok and typeof(field).copyable
+        ok
+  elif T is tuple:
+    block:
+      var ok {.compileTime.} = true
+      for field in default(T).fields:
+        ok = ok and typeof(field).copyable
+      ok
+  elif T is array:
+    typeof(default(T)[low(T)]).copyable
+  else:
+    true
+
 # Forward declarations.
 proc toFlatty*[T](s: var string, x: seq[T])
-proc toFlatty*(s: var string, x: object)
+proc toFlatty*[T: object](s: var string, x: T)
 proc toFlatty*[T: distinct](s: var string, x: T)
 proc toFlatty*[K, V](s: var string, x: SomeTable[K, V])
 proc toFlatty*[K](s: var string, x: CountTable[K])
 proc toFlatty*[N, T](s: var string, x: array[N, T])
 proc toFlatty*[T: tuple](s: var string, x: T)
 proc toFlatty*[T](s: var string, x: ref T)
+proc toFlatty*[T](s: var string, x: SomeSet[T])
+proc toFlatty*(s: var string, x: bool)
+proc toFlatty*(s: var string, x: char)
+proc toFlatty*(s: var string, x: uint8)
+proc toFlatty*(s: var string, x: int8)
+proc toFlatty*(s: var string, x: uint16)
+proc toFlatty*(s: var string, x: int16)
+proc toFlatty*(s: var string, x: uint32)
+proc toFlatty*(s: var string, x: int32)
+proc toFlatty*(s: var string, x: uint64)
+proc toFlatty*(s: var string, x: int64)
+proc toFlatty*(s: var string, x: float32)
+proc toFlatty*(s: var string, x: float64)
+proc toFlatty*(s: var string, x: int)
+proc toFlatty*(s: var string, x: uint)
+proc toFlatty*[T: enum and not range](s: var string, x: T)
+proc toFlatty*(s: var string, x: string)
 
 proc fromFlatty*[T](s: string, i: var int, x: var seq[T])
-proc fromFlatty*(s: string, i: var int, x: var object)
+proc fromFlatty*[T: object](s: string, i: var int, x: var T)
 proc fromFlatty*[T: distinct](s: string, i: var int, x: var T)
 proc fromFlatty*[K, V](s: string, i: var int, x: var SomeTable[K, V])
 proc fromFlatty*[K](s: string, i: var int, x: var CountTable[K])
 proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T])
 proc fromFlatty*[T: tuple](s: string, i: var int, x: var T)
-proc fromFlatty*[T](s: string, x: typedesc[T]): T
 proc fromFlatty*[T](s: string, i: var int, x: var ref T)
+proc fromFlatty*[T](s: string, i: var int, x: var SomeSet[T])
+proc fromFlatty*(s: string, i: var int, x: var bool)
+proc fromFlatty*(s: string, i: var int, x: var char)
+proc fromFlatty*(s: string, i: var int, x: var uint8)
+proc fromFlatty*(s: string, i: var int, x: var int8)
+proc fromFlatty*(s: string, i: var int, x: var uint16)
+proc fromFlatty*(s: string, i: var int, x: var int16)
+proc fromFlatty*(s: string, i: var int, x: var uint32)
+proc fromFlatty*(s: string, i: var int, x: var int32)
+proc fromFlatty*(s: string, i: var int, x: var uint64)
+proc fromFlatty*(s: string, i: var int, x: var int64)
+proc fromFlatty*(s: string, i: var int, x: var int)
+proc fromFlatty*(s: string, i: var int, x: var uint)
+proc fromFlatty*(s: string, i: var int, x: var float32)
+proc fromFlatty*(s: string, i: var int, x: var float64)
+proc fromFlatty*[T: enum and not range](s: string, i: var int, x: var T)
+proc fromFlatty*(s: string, i: var int, x: var string)
+
+# Unsupported runtime resources.
+proc toFlatty*(s: var string, x: pointer) {.error: unsupportedTypeMsg.}
+proc fromFlatty*(s: string, i: var int, x: var pointer) {.error: unsupportedTypeMsg.}
+proc toFlatty*[T](s: var string, x: ptr T) {.error: unsupportedTypeMsg.}
+proc fromFlatty*[T](s: string, i: var int, x: var ptr T) {.error: unsupportedTypeMsg.}
+proc toFlatty*(s: var string, x: cstring) {.error: unsupportedTypeMsg.}
+proc fromFlatty*(s: string, i: var int, x: var cstring) {.error: unsupportedTypeMsg.}
+proc toFlatty*(s: var string, x: proc) {.error: unsupportedTypeMsg.}
+proc fromFlatty*(s: string, i: var int, x: var proc) {.error: unsupportedTypeMsg.}
+
+when not defined(js):
+  proc toFlatty*[T: UnsupportedHandle](s: var string, x: T) {.error: unsupportedTypeMsg.}
+  proc fromFlatty*[T: UnsupportedHandle](s: string, i: var int, x: var T) {.error: unsupportedTypeMsg.}
 
 # Booleans
 proc toFlatty*(s: var string, x: bool) =
@@ -149,7 +239,7 @@ proc fromFlatty*(s: string, i: var int, x: var string) =
 # Seq
 proc toFlatty*[T](s: var string, x: seq[T]) =
   s.addInt64(x.len.int64)
-  when not defined(js) and T.supportsCopyMem:
+  when not defined(js) and T.copyable:
     if x.len == 0:
       return
     let byteLen = x.len * sizeof(T)
@@ -164,7 +254,7 @@ proc fromFlatty*[T](s: string, i: var int, x: var seq[T]) =
   let len = s.readInt64(i)
   i += 8
   x.setLen(len)
-  when not defined(js) and T.supportsCopyMem:
+  when not defined(js) and T.copyable:
     if len > 0:
       copyMem(x[0].addr, s[i].unsafeAddr, len * sizeof(T))
       i += sizeof(T) * len.int
@@ -173,7 +263,7 @@ proc fromFlatty*[T](s: string, i: var int, x: var seq[T]) =
       s.fromFlatty(i, j)
 
 # Objects
-proc toFlatty*(s: var string, x: object) =
+proc toFlatty*[T: object](s: var string, x: T) =
   when x.isObjectVariant:
     s.toFlatty(x.discriminatorField)
     for k, e in x.fieldPairs:
@@ -183,7 +273,7 @@ proc toFlatty*(s: var string, x: object) =
     for e in x.fields:
       s.toFlatty(e)
 
-proc fromFlatty*(s: string, i: var int, x: var object) =
+proc fromFlatty*[T: object](s: string, i: var int, x: var T) =
   when x.isObjectVariant:
     var discriminator: type(x.discriminatorField)
     s.fromFlatty(i, discriminator)
@@ -241,7 +331,7 @@ proc fromFlatty*[K](s: string, i: var int, x: var CountTable[K]) =
 
 # Arrays
 proc toFlatty*[N, T](s: var string, x: array[N, T]) =
-  when not defined(js) and T.supportsCopyMem:
+  when not defined(js) and T.copyable:
     if x.len == 0:
       return
     let byteLen = x.len * sizeof(T)
@@ -253,7 +343,7 @@ proc toFlatty*[N, T](s: var string, x: array[N, T]) =
       s.toFlatty(e)
 
 proc fromFlatty*[N, T](s: string, i: var int, x: var array[N, T]) =
-  when not defined(js) and T.supportsCopyMem:
+  when not defined(js) and T.copyable:
     if x.len > 0:
       copyMem(x[0.N].addr, s[i].unsafeAddr, sizeof(x))
       i += sizeof(x)

--- a/tests/test_flatty.nim
+++ b/tests/test_flatty.nim
@@ -1,6 +1,9 @@
-import 
-  std/[intsets, json, tables, sets],
+import
+  std/[intsets, json, options, tables, sets],
   flatty
+
+when not defined(js):
+  import std/[asyncdispatch, nativesockets]
 
 # Test booleans.
 doAssert true.toFlatty.fromFlatty(bool) == true
@@ -23,6 +26,8 @@ doAssert 123.int8.toFlatty.fromFlatty(int8) == 123
 doAssert 123.int16.toFlatty.fromFlatty(int16) == 123
 doAssert 123.int32.toFlatty.fromFlatty(int32) == 123
 doAssert 123.int64.toFlatty.fromFlatty(int64) == 123
+doAssert cint(123).toFlatty.fromFlatty(cint) == cint(123)
+doAssert cuint(123).toFlatty.fromFlatty(cuint) == cuint(123)
 
 doAssert 123.25.toFlatty.fromFlatty(float) == 123.25
 doAssert $(123.25.float32).toFlatty.fromFlatty(float32) == "123.25"
@@ -68,6 +73,21 @@ type Foo = object
 
 let foo = Foo(id: 32, name: "yes", time: 16.77, active: true)
 doAssert foo.toFlatty().fromFlatty(Foo) == foo
+
+# Test odd Nim object field identifiers.
+type FooBar = object
+  `Foo Bar`: string
+
+let fooBar = FooBar(`Foo Bar`: "Hello World")
+doAssert fooBar.toFlatty.fromFlatty(FooBar) == fooBar
+
+when NimMajor >= 2:
+  # Test default object field values.
+  type Frog = object
+    legs: int = 4
+
+  let frog = Frog()
+  doAssert frog.toFlatty.fromFlatty(Frog) == frog
 
 # Test ref objects.
 type Bar = ref object
@@ -156,6 +176,19 @@ doAssert tup2.toFlatty.fromFlatty(tuple[foo: Foo, id: uint8]) == tup2
 var arrOfTuples: array[2, (int, int)] = [(1, 2), (0, 3)]
 doAssert arrOfTuples.toFlatty.fromFlatty(array[2, (int, int)]) == arrOfTuples
 
+# Test options.
+block:
+  var a: Option[int] = some(123)
+  var b: Option[int]
+  doAssert a.toFlatty.fromFlatty(Option[int]) == a
+  doAssert b.toFlatty.fromFlatty(Option[int]) == b
+
+  type Test = object
+    key: Option[Foo]
+
+  let test = Test(key: some(foo))
+  doAssert test.toFlatty.fromFlatty(Test) == test
+
 when not defined(js):
   # Test intsets
   var intSet = initIntSet()
@@ -176,6 +209,24 @@ var
   person: Person
 doAssert student.toFlatty.fromFlatty(type(student)) == student
 doAssert person.toFlatty.fromFlatty(type(person)) == person
+
+block:
+  var student = Student(name: "Ada", age: 19, id: 42)
+  var student2 = student.toFlatty.fromFlatty(Student)
+  doAssert student2 != nil
+  doAssert student2.name == student.name
+  doAssert student2.age == student.age
+  doAssert student2.id == student.id
+
+  type
+    ValuePerson = object of RootObj
+      name: string
+      age: int
+    ValueStudent = object of ValuePerson
+      id: int
+
+  let valueStudent = ValueStudent(name: "Ada", age: 19, id: 42)
+  doAssert valueStudent.toFlatty.fromFlatty(ValueStudent) == valueStudent
 
 # Test Object variants
 type
@@ -217,6 +268,13 @@ block:
   doAssert nodeNum.toFlatty.fromFlatty(type(nodeNum)).active == nodeNum.active
   doAssert nodeNum2.toFlatty.fromFlatty(type(nodeNum2)).active ==
       nodeNum2.active
+
+  let nodes = @[nodeNum, nodeNum2]
+  let nodes2 = nodes.toFlatty.fromFlatty(type(nodes))
+  doAssert nodes2[0].kind == nkFloat
+  doAssert nodes2[0].floatVal == nodeNum.floatVal
+  doAssert nodes2[1].kind == nkInt
+  doAssert nodes2[1].intVal == nodeNum2.intVal
 
 var jsonNode = parseJson("{\"json\": true, \"count\":20}")
 doAssert jsonNode.toFlatty.fromFlatty(type(jsonNode)) == jsonNode
@@ -273,5 +331,39 @@ block:
   doAssert hSet3.toFlatty.fromFlatty(HashSet[float64]) == hSet3
   let hSet4 = toOrderedSet([1.1, 2.2, 3.3])
   doAssert hSet4.toFlatty.fromFlatty(OrderedSet[float64]) == hSet4
+
+static:
+  type
+    PtrObject = object
+      p: pointer
+      value: int
+    CstringObject = object
+      text: cstring
+    Callback = proc (value: int): int
+    CallbackObject = object
+      cb: Callback
+    RawAddress = distinct pointer
+
+  doAssert not compiles(default(pointer).toFlatty)
+  doAssert not compiles(default(ptr int).toFlatty)
+  doAssert not compiles(default(cstring).toFlatty)
+  doAssert not compiles(default(Callback).toFlatty)
+  doAssert not compiles(default(RawAddress).toFlatty)
+  when declared(AsyncFD):
+    doAssert not compiles(default(AsyncFD).toFlatty)
+    doAssert not compiles(default(seq[AsyncFD]).toFlatty)
+  when declared(SocketHandle):
+    doAssert not compiles(default(SocketHandle).toFlatty)
+    doAssert not compiles(default(seq[SocketHandle]).toFlatty)
+
+  doAssert not compiles(default(PtrObject).toFlatty)
+  doAssert not compiles(default(CstringObject).toFlatty)
+  doAssert not compiles(default(CallbackObject).toFlatty)
+
+  doAssert not compiles(@[default(PtrObject)].toFlatty)
+  doAssert not compiles([default(ptr int)].toFlatty)
+  doAssert not compiles([default(cstring)].toFlatty)
+  doAssert not compiles(@[default(Callback)].toFlatty)
+  doAssert not compiles(@[default(RawAddress)].toFlatty)
 
 echo "DONE"


### PR DESCRIPTION
## Summary
- add a Flatty-specific copy-mem safety predicate so raw-copy fast paths do not serialize pointer-like runtime resources
- reject raw pointers, cstrings, procs, FileHandle, SocketHandle, and AsyncFD at compile time, including when nested in objects and containers
- expand tests for odd Nim object shapes inspired by jsony: spaced field identifiers, default fields, options, inherited objects, variant sequences, and unsupported runtime resources
- document that only Nim-owned values are supported

## Checks
- `nim r tests\tests.nim`
- `nim js -r tests\test_flatty.nim`
- `nim js -r tests\jstest_jsbinny.nim`