### PR TITLE
Require little-endian native targets

### DIFF
--- a/src/flatty/binny.nim
+++ b/src/flatty/binny.nim
@@ -1,3 +1,6 @@
+when cpuEndian != littleEndian:
+  {.error: "flatty only supports little-endian native targets".}
+
 # Like StringStream but without the Stream and side effects.
 
 type Buffer = string | seq[uint8]


### PR DESCRIPTION

- add a compile-time little-endian guard at the top of `flatty/binny.nim`
- fail native big-endian targets before using Flatty's raw byte-copy serialization helpers
